### PR TITLE
fix(cicd): group mypy renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Update Poetry mypy and build-system mypyc together",
+      "matchFileNames": ["pyproject.toml"],
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": ["mypy"],
+      "groupName": "mypy",
+      "groupSlug": "mypy"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds a Renovate package rule for `mypy`.

## Rationale

Prevents Poetry `mypy` and build-system `mypy[mypyc]` from drifting, so generated C rebuild PRs use the intended mypyc version.

## Details

Matches PyPI package `mypy` in `pyproject.toml`, covering both Poetry dev deps and build-system requirements.

## Validation

- `python3 -m json.tool renovate.json`
- `git diff --check`