### PR TITLE
fix(cicd): keep mypy and mypyc renovate updates in sync

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,28 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update build-system mypyc requirement",
+      "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"],
+      "matchStrings": ["\"mypy\\[mypyc\\]==(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "mypy",
+      "packageNameTemplate": "mypy",
+      "datasourceTemplate": "pypi",
+      "versioningTemplate": "pep440",
+      "depTypeTemplate": "build-system.requires"
+    }
+  ],
   "packageRules": [
     {
       "description": "Update Poetry mypy and build-system mypyc together",
-      "matchFileNames": ["pyproject.toml"],
+      "matchFileNames": ["/(^|/)pyproject\\.toml$/"],
       "matchDatasources": ["pypi"],
       "matchPackageNames": ["mypy"],
       "groupName": "mypy",
-      "groupSlug": "mypy"
+      "groupSlug": "mypy",
+      "separateMajorMinor": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds a Renovate regex custom manager for the build-system `mypy[mypyc]` pin and tightens the `mypy` package rule.

## Rationale
Prevents Poetry `mypy` and build-system `mypy[mypyc]` from drifting, so generated C rebuild PRs use the intended mypyc version.

## Details
Extracts `mypy[mypyc]==...` from `pyproject.toml` as PyPI package `mypy` with PEP 440 versioning, then groups it with Poetry's `mypy` dependency and disables major/minor splitting for that group.

After this merges, Renovate should rerun against the existing mypy PRs and converge on one active mypy PR that updates the Poetry dev dependency, the build-system `mypy[mypyc]` requirement, and `poetry.lock`.

## Test Plan
- `git fetch origin master` passed; branch was created from current `origin/master`.
- `python3 -m json.tool renovate.json` passed.
- `rg -n -P '"mypy\\[mypyc\\]==(?<currentValue>[^\"]+)"' pyproject.toml` passed; matched line 37: `"mypy[mypyc]==1.20.2",`.
- `git diff --check` passed.
- `renovate --version` could not run because `renovate` is not installed locally.
- `renovate-config-validator --version` could not run because `renovate-config-validator` is not installed locally.
- Python tests were not run because this is a config-only Renovate change.
- `pip install .` was not run, to avoid generating tracked `build/` output for a config-only PR.
